### PR TITLE
fix(deps): update Go to 1.26.0 and kubernetes-entrypoint to latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM golang:1.23.1 AS build
+FROM golang:1.26.0 AS build
 # renovate: name=airship/kubernetes-entrypoint repo=https://opendev.org/airship/kubernetes-entrypoint.git branch=master
-ARG KUBERNETES_ENTRYPOINT_GIT_REF=cc2737be5285951ac08b32e76dfd375e1a0ab81f
+ARG KUBERNETES_ENTRYPOINT_GIT_REF=15b84102d9f2d106657412054aac29b5c6fbdba4
 ADD https://opendev.org/airship/kubernetes-entrypoint.git#${KUBERNETES_ENTRYPOINT_GIT_REF} /src
 WORKDIR /src
 RUN CGO_ENABLED=0 GOOS=linux go build -o /main


### PR DESCRIPTION
## Problem

CI has been failing since April 2025 due to Trivy finding known CVEs in the Go binary dependencies. The `image / build` job fails because `fail-on-vulnerability: true` is set for PR builds.

## Root Cause

- `golang:1.23.1` is outdated
- `kubernetes-entrypoint` at commit `cc2737b` has old Go dependencies with known CVEs (e.g., `golang.org/x/net v0.33.0`, `golang.org/x/sys v0.28.0`)

## Fix

- Update Go from `1.23.1` to `1.26.0`
- Update kubernetes-entrypoint from `cc2737b` to `15b8410` (latest on master)
  - This brings in `golang.org/x/net v0.49.0`, `golang.org/x/sys v0.40.0`, `k8s.io/client-go v0.35.0`, etc.

This supersedes Renovate PRs #2 and #4 by combining both updates into a single PR.

---

_Recreated from upstream branch (not fork) to fix Depot OIDC authentication._